### PR TITLE
Fix when login items list is empty

### DIFF
--- a/Lib/LoginServiceKit/LoginServiceKit.swift
+++ b/Lib/LoginServiceKit/LoginServiceKit.swift
@@ -65,9 +65,11 @@ public final class LoginServiceKit: NSObject {
         guard isExistLoginItems(at: path) == false else {
             return false
         }
-        guard let (list, items) = snapshot, let item = items.last else {
+        guard let (list, items) = snapshot else {
             return false
         }
+        
+        let item = unsafeBitCast(items.last ?? nil, to: LSSharedFileListItem.self)
         return LSSharedFileListInsertItemURL(list, item, nil, nil, URL(fileURLWithPath: path) as CFURL, nil, nil) != nil
     }
 

--- a/Lib/LoginServiceKit/LoginServiceKit.swift
+++ b/Lib/LoginServiceKit/LoginServiceKit.swift
@@ -68,8 +68,7 @@ public final class LoginServiceKit: NSObject {
         guard let (list, items) = snapshot else {
             return false
         }
-        
-        let item = unsafeBitCast(items.last ?? nil, to: LSSharedFileListItem.self)
+        let item = unsafeBitCast(items.last, to: LSSharedFileListItem.self)
         return LSSharedFileListInsertItemURL(list, item, nil, nil, URL(fileURLWithPath: path) as CFURL, nil, nil) != nil
     }
 


### PR DESCRIPTION
Fixes #29

Passing `nil` seems to work fine. However Swift complains since the argument is not optional hence the `unsafeBitCast`.